### PR TITLE
Fixing SpuCo MNIST loading bug by removing lambda function

### DIFF
--- a/src/spuco/datasets/spuco_mnist.py
+++ b/src/spuco/datasets/spuco_mnist.py
@@ -18,6 +18,9 @@ from spuco.datasets import (TEST_SPLIT, TRAIN_SPLIT, VAL_SPLIT,
 from spuco.datasets.spuco_mnist_config import config
 from spuco.utils.random_seed import seed_randomness
 
+class GrayscaleToRGBTransform():
+    def __call__(self, x):
+        return torch.stack([x[0], x[0], x[0]], dim=0)  # convert grayscale to RGB
 
 class ColourMap(Enum):
     HSV = "hsv"
@@ -112,7 +115,7 @@ class SpuCoMNIST(BaseSpuCoDataset):
             download=self.download,
             transform=T.Compose([
                 T.ToTensor(),
-                T.Lambda(lambda x: torch.cat([x, x, x], dim=0))  # convert grayscale to RGB
+                T.transforms.Lambda(GrayscaleToRGBTransform())  # convert grayscale to RGB
             ])
         )
             


### PR DESCRIPTION
**Updated the file src/spuco/datasets/spuco_mnist.py to fix a bug when attempting to train a model using loaded SpuCo MNIST data.**

In the load_data function, replaced a lambda function for transforming the data into RGB with a separate, equivalent function implemented in the GrayscaleToRGBTransform class.

This allows the data set to be pickled during the for loop used when training a model.



Example ------------------------------------

trainset = SpuCoMNIST(
    root="/data/mnist/",
    spurious_feature_difficulty=difficulty,
    spurious_correlation_strength=0.995,
    classes=classes,
    split="train"
)
trainset.initialize()

testset = SpuCoMNIST(
    root="/data/mnist/",
    spurious_feature_difficulty=difficulty,
    classes=classes,
    split="test"
)
testset.initialize()

model = model_factory("lenet", trainset[0][0].shape, trainset.num_classes)

erm = ERM(
    model=model,
    num_epochs=1,
    trainset=trainset,
    batch_size=64,
    optimizer=SGD(model.parameters(), lr=1e-3, weight_decay=5e-4, momentum=0.9, nesterov=True),
    #device=device,
    verbose=True
)

erm.train()  - this used to give an unable to pickle object error due to the lambda function used when loading the train and test sets. Now, this should run correctly.

In the trainer.py file:

with tqdm(self.trainloader, unit="batch", total=len(self.trainloader), disable=not self.verbose) as pbar:

previously caused the pickle error due to the lambda function

-------------------------------------------

